### PR TITLE
fix for lie jacobian

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -21,7 +21,10 @@
             "macFrameworkPath": [
                 "/System/Library/Frameworks",
                 "/Library/Frameworks"
-            ]
+            ],
+            "compilerPath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30037\\bin\\Hostx64\\x64\\cl.exe",
+            "cStandard": "c17",
+            "cppStandard": "c++17"
         },
         {
             "name": "Linux",
@@ -54,7 +57,10 @@
                 ],
                 "limitSymbolsToIncludedHeaders": true,
                 "databaseFilename": ""
-            }
+            },
+            "compilerPath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30037\\bin\\Hostx64\\x64\\cl.exe",
+            "cStandard": "c17",
+            "cppStandard": "c++17"
         },
         {
             "name": "Win32",
@@ -74,8 +80,12 @@
                 ],
                 "limitSymbolsToIncludedHeaders": true,
                 "databaseFilename": ""
-            }
+            },
+            "compilerPath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30037\\bin\\Hostx64\\x64\\cl.exe",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "configurationProvider": "ms-vscode.cmake-tools"
         }
     ],
-    "version": 3
+    "version": 4
 }

--- a/parametersse3.cpp
+++ b/parametersse3.cpp
@@ -126,7 +126,7 @@ bool PoseSE3Parameterization<6>::ComputeJacobian(const double *x, double *jacobi
     double R[9];
     ceres::AngleAxisToRotationMatrix(x, R);
     Eigen::Matrix<double, 3, 3, Eigen::RowMajor> R_cam(R);
-    J.block<3, 3>(0, 0) = R_cam;
+    J.block<3, 3>(0, 0) = -R_cam;
 
     
     return true;

--- a/parametersse3.cpp
+++ b/parametersse3.cpp
@@ -122,6 +122,13 @@ bool PoseSE3Parameterization<6>::ComputeJacobian(const double *x, double *jacobi
 {
     Eigen::Map<Eigen::Matrix<double, 6, 6, Eigen::RowMajor> > J(jacobian);
     J.setIdentity();
+    
+    double R[9];
+    ceres::AngleAxisToRotationMatrix(x, R);
+    Eigen::Matrix<double, 3, 3, Eigen::RowMajor> R_cam(R);
+    J.block<3, 3>(0, 0) = R_cam;
+
+    
     return true;
 }
 

--- a/parametersse3.cpp
+++ b/parametersse3.cpp
@@ -126,7 +126,7 @@ bool PoseSE3Parameterization<6>::ComputeJacobian(const double *x, double *jacobi
     double R[9];
     ceres::AngleAxisToRotationMatrix(x, R);
     Eigen::Matrix<double, 3, 3, Eigen::RowMajor> R_cam(R);
-    J.block<3, 3>(0, 0) = -R_cam;
+    J.block<3, 3>(0, 0) = R_cam;
 
     
     return true;


### PR DESCRIPTION
Fixed the jacobian for the lie parameterization. Is not the identity for the rotation block it is the rotation itself.

<img src="https://latex.codecogs.com/svg.image?exp(\omega&space;)R_{\omega=0}^{}&space;\approx&space;(I&space;&plus;&space;\[\omega]_x)R" title="exp(\omega )R_{\omega=0}^{} \approx (I + \[\omega]_x)R" />

<img src="https://latex.codecogs.com/svg.image?\frac{\partial&space;(R&space;&plus;&space;\[\omega]_xR)}{\partial&space;\omega}&space;=&space;R" title="\frac{\partial (R + \[\omega]_xR)}{\partial \omega} = R" />